### PR TITLE
Start fixing payment page actions bug

### DIFF
--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <%= form_tag '/payments', method: 'get', id: 'list_config' do %>
+  <%= form_tag 'payments', method: 'get', id: 'list_config' do %>
     <div class="bs-docs-section">
       <fieldset>
         <div class="form-group">
@@ -62,7 +62,7 @@
     </div>
   <% end %>
 
-  <%= form_tag '/payments/confirm', id: 'payment_form' do %>
+  <%= form_tag 'payments/confirm', id: 'payment_form' do %>
     <div class="bs-docs-section">
       <fieldset>
         <div class="row">


### PR DESCRIPTION
/paymentsページのform_tagが間違っていたので修正します。

before

```
<%= form_tag '/payments〜
```

after

```
<%= form_tag 'payments〜
```
