### PR TITLE
paymentsページの支払情報テーブルの行全体をクリックできるようにする

### DIFF
--- a/app/assets/javascripts/settleup.js
+++ b/app/assets/javascripts/settleup.js
@@ -2,13 +2,34 @@ $(function() {
   // disable settleup button when page loaded
   $("#settleup").prop('disabled', true);
 
-  // enable/disable settleup button when checkbox clicked
-  $(":checkbox").click(function() {
+  // enable/disable settleup button
+  function toggle_settleup_button() {
     if ($("[name='payment_ids[]']:checked").length > 0) {
       $("#settleup").removeAttr('disabled');
     } else {
       $("#settleup").prop('disabled', true);
     }
+  };
+
+  // toggle checkbox when checkbox clicked
+  $(":checkbox[name='payment_ids[]']").click(function() {
+    if ( $(this).prop('checked') ) {
+      $(this).prop('checked', '');
+    } else {
+      $(this).prop('checked', 'checked');
+    }
+    toggle_settleup_button();
+  });
+
+  // toggle checkbox when table row clicked
+  $("table tr").click(function() {
+    var checkbox = $(this).children("td").children(":checkbox");
+    if ( checkbox.prop('checked') ) {
+      checkbox.prop('checked', '');
+    } else {
+      checkbox.prop('checked', 'checked');
+    }
+    toggle_settleup_button();
   });
 });
 

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -95,7 +95,7 @@
                       <% if payment.status? %>
                         <td>精算済</td>
                       <% else %>
-                        <td><label><input type='checkbox' id='payment_<%= payment.id %>' name='payment_ids[]' value='<%= payment.id %>'>精算する</label></td>
+                        <td><input type='checkbox' id='payment_<%= payment.id %>' name='payment_ids[]' value='<%= payment.id %>'>精算する</td>
                       <% end %>
                     </tr>
                   <% end %>


### PR DESCRIPTION
paymentsページの支払情報テーブルの挙動を変えます。

**チェックボックス(と、そのラベル)をクリックすると、そのチェックボックスがon/offできていました**が、チェックボックスが小さくて押しにくいと思ったので、**行のどこかをクリックすると、そのチェックボックスがon/offできる**ように変更しようと思います。
